### PR TITLE
update lodash to 4.17.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 
   "dependencies"    : {
                         "async"           : "~ 0.2.9",
-                        "lodash"          : "~ 2.4.1"
+                        "lodash"          : "~ 4.17.10"
                       },
   "devDependencies" : { "vows" : "*" }
 }


### PR DESCRIPTION
Update lodash from 2.4.1 to 4.17.10 to remove warnings from npm about
a security vulnerability in lodash.